### PR TITLE
[fix] Avoid spams.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,4 +8,4 @@ Welcome to Zhuobin's online space. You will find math handouts and other useful 
 
 <br />
 <hr />
-<a href="mailto:{{ site.owner.email }}"><i class="fa fa-envelope-o" aria-hidden="true"></i> liang-teaching@outlook.com</a>
+<a href="mailto:{{ site.author.email }}"><i class="fa fa-envelope-o" aria-hidden="true"></i> liang-teaching#outlook.com</a>


### PR DESCRIPTION
In _config.yml, "email" node is in "author" node, not in "owner" node, which makes generated index.html doesn't have an actual hyperlink of that email.
Also, using hash mark "#" instead of at mark "@" can avoid some (NOT ALL) email crawlers. Especially, many email crawlers are running on GitHub Pages.